### PR TITLE
Bump Cartopy to 0.21.1

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,7 +2,7 @@ affine==2.3.0
 amqp==5.0.6
 appdirs==1.4.4
 attrs==21.2.0
-Cartopy==0.18.0
+Cartopy==0.21.1
 celery==5.2.0
 cronex==0.1.3.1
 Django==3.2.13


### PR DESCRIPTION
Cartopy has `shapely` as a dependency and the latest version of `shapely` (released [three weeks ago](https://github.com/shapely/shapely/releases/tag/2.0.0)) no longer uses `lgeos` causing an error (#78) when installing SURFACE.

Cartopy [merged a fix](https://github.com/SciTools/cartopy/commit/431372b6a3d30f93c57796c564c223cf3fffa062) on 11 September and a new version of Cartopy was [released](https://github.com/SciTools/cartopy/releases/tag/v0.21.1) with the following description: *"This is a patch release to allow shapely 2.0 to be installed and used with Cartopy."*

This PR bumps Cartopy to 0.21.1 and
Fixes #78