### PR TITLE
Add Swagger API documentation and add data ingestion from NASA API

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -32,3 +32,4 @@ gunicorn==20.1.0
 croniter==1.3.5
 django-ckeditor==6.5.1
 django-simple-history==3.3.0
+drf-spectacular==0.27.2

--- a/api/tempestas_api/settings.py
+++ b/api/tempestas_api/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     'colorfield',
     'import_export',
     'simple_history',
+    'drf_spectacular',
 ]
 
 CKEDITOR_CONFIGS = {
@@ -169,12 +170,21 @@ DOCUMENTS_ROOT = os.path.join('/data/media', 'documents')
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 200,
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     )
+}
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Surface API',
+    'DESCRIPTION': 'API Documentation',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+    # OTHER SETTINGS
 }
 
 SIMPLE_JWT = {

--- a/api/tempestas_api/urls.py
+++ b/api/tempestas_api/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     path('password/', change_password, name='change_password'),
     path('admin/', admin.site.urls),
     path('', include('wx.urls')),
+    path('', include('wx.urls_dir.api_urls')),
 ]
 
 admin.site.site_header = 'Surface Admin Area'

--- a/api/wx/decoders/json_nasa.py
+++ b/api/wx/decoders/json_nasa.py
@@ -1,0 +1,187 @@
+# tentativo di decoder per json nasa
+
+import json
+import logging
+import time
+from datetime import datetime
+
+import pytz
+from celery import shared_task
+
+from wx.decoders.insert_raw_data import insert
+from wx.decoders.insert_hf_data import insert as insert_hf
+from wx.models import VariableFormat, Station, StationVariable
+from wx.utils import update_station_variables
+
+logger = logging.getLogger('surface.json_nasa')
+db_logger = logging.getLogger('db')
+
+FORMAT = "JSON_NASA"
+
+
+def convert_string_2_datetime(text, utc_offset):
+    """Conversion of date from string to datetime"""
+
+    year = text[0:4]
+    month = text[4:6]
+    day = text[6:8]
+    hour = 0
+
+    if len(text) == 10:
+        hour = text[8:10]
+
+    datetime_offset = pytz.FixedOffset(utc_offset)
+    date = datetime(year=int(year), month=int(month), day=int(day), hour=int(hour), tzinfo=datetime_offset)
+
+    return date
+
+
+def parse_line(line, station, lookup_table, utc_offset):
+    """Conversion of dictionary data to raw_data format"""
+
+    str_date, value = line
+    date_info = convert_string_2_datetime(str_date, utc_offset)
+
+    if lookup_table['seconds'] == 86400:
+        parsed_line = (station.id, lookup_table['variable_id'], lookup_table['seconds'], date_info, float(value), 1, None, None, None, None, None, None, None, None, True)
+    else:
+        parsed_line = (station.id, lookup_table['variable_id'], lookup_table['seconds'], date_info, float(value), 1, None, None, None, None, None, None, None, None, False)
+
+    return parsed_line
+
+
+def fields_extraction(data,  type):
+    """Extract the name of the dataset's variable"""
+
+    if type == "FeatureCollection":
+        fields = list(data["parameterInformation"].keys())
+    elif type == "Feature":
+        fields = list(data["parameters"].keys())
+
+    logger.info(f"Fields names: {str(fields)}")
+
+    return fields
+
+
+def coordinates_extraction(feature):
+    """Extract the coordinates of the station from a feature"""
+
+    coordinates = feature["geometry"]["coordinates"]
+
+    logger.info(f"Coordinates: {coordinates}")
+
+    return coordinates
+
+
+def extract_lookup(station, fields):
+    """New version of parse_second_line_header"""
+
+    variable_format_list = VariableFormat.objects.all()
+
+    lookup_table = {}
+    in_file_station_variables = set()
+
+    for variable_format in variable_format_list:
+
+        # check if lookup_key is not duplicated
+        if variable_format.lookup_key in lookup_table:
+            db_logger.error(f"key {variable_format.lookup_key} is already "
+                            f"present in lookup table: {variable_format}")
+
+        lookup_table[variable_format.lookup_key] = {
+            'variable_id': variable_format.variable.id,
+            'seconds': variable_format.interval.seconds
+        }
+
+    result = {}
+
+    for field in fields:
+        if field in lookup_table.keys():
+            variable = lookup_table[field]
+            in_file_station_variables.add(variable['variable_id'])
+        else:
+            db_logger.warning(f'Variable {field} not found while parsing document from station {station.name}')
+            variable = None
+
+        result[field] = variable
+
+    # associate new variable on station
+    update_station_variables(station, in_file_station_variables)
+
+    """
+    forma output:
+    {
+        nome_campo_dataset:{
+            "variable_id":value_id_database,
+            "seconds":value
+        },
+        ...
+    }
+    """
+
+    return result
+
+
+def process_feature(feature, fields, reads,  utc_offset):
+    """Outsourcing of feature processing"""
+
+    coordinates = coordinates_extraction(feature=feature)
+    station = Station.objects.get(longitude=coordinates[0], latitude=coordinates[1])
+    station_code = station.code
+
+    logger.info(f"Station code: {station_code}")
+
+    lookup_table = extract_lookup(station, fields)
+
+    logger.info(f"Lookup table: {str(lookup_table)}")
+
+    for field in fields:
+        for key, value in feature["properties"]["parameter"][field].items():
+            parsed_line = parse_line((key, value), station, lookup_table[field], utc_offset)
+            reads.append(parsed_line)
+
+
+@shared_task
+def read_file(filename, highfrequency_data=False, station_object=None, utc_offset=-360, override_data_on_conflict=False):
+    """Read a json file and return a seq of records or nil in case of error"""
+
+    logger.info('processing %s' % filename)
+    start = time.time()
+
+    reads = []
+
+    try:
+        with open(filename, 'r', encoding='UTF-8') as source:
+            
+            data = json.load(source)
+
+            type = data["type"]
+            fields = fields_extraction(data, type)
+
+            if type == "FeatureCollection":
+                
+                for feature in data["features"]:
+                    process_feature(feature, fields, reads,  utc_offset)
+
+            elif type == "Feature":
+                process_feature(data, fields, reads, utc_offset)
+
+    except FileNotFoundError as fnf:
+        logger.error(repr(fnf))
+        print('No such file or directory {}.'.format(filename))
+        raise
+    except Exception as e:
+        logger.error(repr(e))
+        raise
+
+    if highfrequency_data:
+        insert_hf(reads, override_data_on_conflict)
+    else:
+        insert(reads, override_data_on_conflict)
+
+    end = time.time()
+
+    logger.info(f'Processing file {filename} in {end - start} seconds, '
+                f'returning #reads={len(reads)}.')
+
+    return reads

--- a/api/wx/serializers.py
+++ b/api/wx/serializers.py
@@ -152,6 +152,24 @@ class StationSerializerRead(serializers.ModelSerializer):
         )
 
 
+class StationSerializer(serializers.ModelSerializer):
+    """
+    Serializer class for the Station model, 
+    """
+
+    profile = serializers.IntegerField(source="profile.id")
+    country = serializers.IntegerField(source="country.id")
+    data_source = serializers.IntegerField(source="data_source.id")
+    communication_type = serializers.IntegerField(source="communication_type.id")
+    wmo_station_type = serializers.IntegerField(source="wmo_station_type.id")
+    wmo_region = serializers.IntegerField(source="wmo_region.id")
+    wmo_program = serializers.IntegerField(source="wmo_program.id")
+
+    class meta:
+        models = models.Station
+        fields = '__all__'
+
+
 class StationSerializerReadSimple(serializers.ModelSerializer):
     class Meta:
         model = models.Station

--- a/api/wx/urls.py
+++ b/api/wx/urls.py
@@ -1,38 +1,12 @@
 from django.conf import settings
 from django.conf.urls.static import static
-from django.urls import path, include
-from rest_framework import routers
+from django.urls import path
 
 from django.contrib.auth.decorators import login_required
 
 from wx import views
 
-router = routers.DefaultRouter()
-router.register(r'station_images', views.StationImageViewSet)
-router.register(r'station_files', views.StationFileViewSet)
-router.register(r'quality_flags', views.QualityFlagList)
-router.register(r'stations_metadata', views.StationMetadataViewSet)
-
 urlpatterns = [
-    path('api/stations/metadata', include(router.urls)),
-    path('api/administrative_regions/', views.AdministrativeRegionViewSet.as_view({'get': 'list'})),
-    path('api/stations/', views.StationViewSet.as_view({'get': 'list', 'post': 'create', 'put': 'update'})),
-    path('api/stations_simple/', views.StationSimpleViewSet.as_view({'get': 'list'})),
-    path('api/station_profiles/', views.StationProfileViewSet.as_view({'get': 'list'})),
-    path('api/stations_variables/', views.StationVariableViewSet.as_view({'get': 'list'})),
-    path('api/stations_variables/stations/', views.StationVariableStationViewSet.as_view({'get': 'list'})),
-    path('api/variables/', views.VariableViewSet.as_view({'get': 'list'})),
-    path('api/watersheds/', views.WatershedList.as_view()),
-    path('api/station_communications/', views.StationCommunicationList.as_view()),
-    path('api/livedata/<code>/', views.livedata),
-    path('api/rawdata/', views.raw_data_list),
-    path('api/hourlysummaries/', views.hourly_summary_list),
-    path('api/dailysummaries/', views.daily_summary_list),
-    path('api/monthlysummaries/', views.monthly_summary_list),
-    path('api/yearlysummaries/', views.yearly_summary_list),
-    path('api/last24hrsummaries/', views.last24_summary_list),
-    path('api/station_telemetry_data/<str:date>', views.station_telemetry_data),
-    path('api/', include(router.urls)),
     path('', views.StationsMapView.as_view(), name='stations-map'),
     path('station_geo_features/<str:lon>/<str:lat>', views.station_geo_features),
     path('decoders/', views.DecoderList.as_view()),
@@ -56,12 +30,9 @@ urlpatterns = [
     path('wx/stations/<int:pk_station>/variables/<int:pk>/delete/', views.StationVariableDeleteView.as_view(),
          name='stationvariable-delete'),
     path('wx/products/station_report/', views.StationReportView.as_view(), name='station-report'),
-    path('api/station_report/', views.station_report_data, name='station_report_data'),
     path('wx/variablereport/', views.VariableReportView.as_view(), name='variable-report'),
     path('wx/product/compare/', views.ProductCompareView.as_view(), name='product-compare'),
     path('wx/quality_control/validation/', views.QualityControlView.as_view(), name='quality-control'),
-    path('api/quality_control/', views.qc_list),
-    path('api/variable-report/', views.variable_report_data, name='variable-report-data'),
     path('wx/data/capture/', views.DataCaptureView, name='data-capture'),
     path('wx/data/export/', views.DataExportView.as_view(), name='data-export'),
     path('wx/data/export/files/', views.DataExportFiles, name='data-export-files'),
@@ -85,16 +56,8 @@ urlpatterns = [
     path('wx/spatial_analysis/color_bar', views.GetColorMapBar, name='spatial-analysis-color-bar'),
     path('coming-soon', views.ComingSoonView.as_view(), name='coming-soon'),
     path('coming-soon-qc', views.ComingSoonView.as_view(), name='coming-soon-qc'),
-    path('api/raw_data_last_24h/<station_id>/', views.raw_data_last_24h),
-    path('api/latest_data/<variable_id>/', views.latest_data),
     path('wx/product/extremes_means/', views.ExtremesMeansView.as_view(), name='extremes-means'),
-    path('api/daily_means/', views.daily_means_data_view),
     path('wx/data/inventory/', views.DataInventoryView.as_view(), name='data-inventory'),
-    path('api/data_inventory/', views.get_data_inventory),
-    path('api/data_inventory_by_station/', views.get_data_inventory_by_station),
-    path('api/station_variable_data_month_inventory/', views.get_station_variable_month_data_inventory),
-    path('api/station_variable_data_day_inventory/', views.get_station_variable_day_data_inventory),
-    path('api/range_threshold/', views.range_threshold_view), # For synop and daily data capture
     path('wx/quality_control/update_reference_station/', views.update_reference_station),    
     path('wx/quality_control/global_threshold/update/', views.update_global_threshold),
     path('wx/quality_control/range_threshold/', views.get_range_threshold_form, name='range-threshold'),

--- a/api/wx/urls_dir/api_urls.py
+++ b/api/wx/urls_dir/api_urls.py
@@ -1,0 +1,48 @@
+from django.urls import path, include
+from wx import views
+from rest_framework import routers
+
+
+router = routers.DefaultRouter()
+router.register(r'station_images', views.StationImageViewSet)
+router.register(r'station_files', views.StationFileViewSet)
+router.register(r'quality_flags', views.QualityFlagList)
+
+urlpatterns = [
+    path('api/', include(router.urls)),
+    path('api/stations/metadata/', include(router.urls)),
+
+    path('api/administrative_regions/', views.AdministrativeRegionViewSet.as_view({'get': 'list'})),
+    path('api/stations/', views.StationViewSet.as_view({'get': 'list', 'post': 'create', 'put': 'update'})),
+    path('api/stations_simple/', views.StationSimpleViewSet.as_view({'get': 'list'})),
+    path('api/station_profiles/', views.StationProfileViewSet.as_view({'get': 'list'})),
+    path('api/stations_variables/', views.StationVariableViewSet.as_view({'get': 'list'})),
+    path('api/stations_variables/stations/', views.StationVariableStationViewSet.as_view({'get': 'list'})),
+
+    path('api/stations/metadata/', views.StationMetadataViewSet.as_view({'get': 'list'})),
+
+    path('api/variables/', views.VariableViewSet.as_view({'get': 'list'})),
+    path('api/watersheds/', views.WatershedList.as_view()),
+    path('api/station_communications/', views.StationCommunicationList.as_view()),
+    path('api/livedata/<str:code>', views.livedata),
+    path('api/rawdata/', views.raw_data_list),
+    path('api/hourlysummaries/', views.hourly_summary_list),
+    path('api/dailysummaries/', views.daily_summary_list),
+    path('api/monthlysummaries/', views.monthly_summary_list),
+    path('api/yearlysummaries/', views.yearly_summary_list),
+    path('api/last24hrsummaries/', views.last24_summary_list),
+    path('api/station_telemetry_data/<str:date>', views.station_telemetry_data),
+    path('api/station_report/', views.station_report_data, name='station_report_data'),
+    path('api/quality_control/', views.qc_list),
+    path('api/variable-report/', views.variable_report_data, name='variable-report-data'),
+    path('api/raw_data_last_24h/<station_id>/', views.raw_data_last_24h),
+    path('api/latest_data/<variable_id>/', views.latest_data),
+    path('api/daily_means/', views.daily_means_data_view),
+    path('api/data_inventory/', views.get_data_inventory),
+    path('api/data_inventory_by_station/', views.get_data_inventory_by_station),
+    path('api/station_variable_data_month_inventory/', views.get_station_variable_month_data_inventory),
+    path('api/station_variable_data_day_inventory/', views.get_station_variable_day_data_inventory),
+    path('api/range_threshold/', views.range_threshold_view),
+
+    path('', include('wx.urls_dir.spectacular')),
+]

--- a/api/wx/urls_dir/spectacular.py
+++ b/api/wx/urls_dir/spectacular.py
@@ -1,0 +1,10 @@
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
+from django.urls import path
+
+urlpatterns = [
+    # YOUR PATTERNS
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    # Optional UI:
+    path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
+]


### PR DESCRIPTION
-**Swagger API**:
We have developed the Swagger API documentation for the Surface URLs. 
The development work primarily involved adding the extend_schema decorator from the drf_spectacular library to each of the involved views. This allowed us to include a brief description of the API's purpose, the various parameters used, and, in some cases, the allowed responses for each endpoint.

-**Data Ingestion from NASA API**: 
We have developed a new decoder for JSON files provided by NASA's Power Data APIs, similar in functionality to the existing ones. This required adding a new line in both the Format and Decoder tables with the name “JSON_NASA.” Additionally, we have enabled SURFACE to make API requests to external sources like NASA Power Data, allowing periodic data retrieval and storage without an FTP server. These features use existing models, a new “cron_scheduler” field in the Station table was added to schedule data retrieval tasks